### PR TITLE
DEP: un-expose dev-only Python dependencies using PEP 735 dependency groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,11 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        enable-cache: false
+
     # Rust
     - name: Format
       run: cargo fmt --check --verbose
@@ -24,17 +28,12 @@ jobs:
       run: cargo build --verbose
     # Python
     - name: Install - python
-      run: |
-        python -m venv ../env
-        source ../env/bin/activate
-        pip install maturin
-        maturin develop
-        pip install -e .[test]
+      run: uv sync --extra test
     - name: Format - python
-      run: source ../env/bin/activate; ruff check ./interpn
+      run: ucx ruff check ./interpn
     - name: Static typing - python
-      run: source ../env/bin/activate; pyright ./interpn
+      run: uvx pyright ./interpn
     - name: Test - python
       run: |
-        source ../env/bin/activate; pytest .
-        python ./examples/cubic_comparison.py test
+        uv run --no-sync pytest .
+        uv run --no-sync examples/cubic_comparison.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       run: cargo build --verbose
     # Python
     - name: Install - python
-      run: uv sync --extra test
+      run: uv sync --group test
     - name: Format - python
       run: ucx ruff check ./interpn
     - name: Static typing - python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pydantic >= 2.5.2",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     "pytest >= 8.0",
     "coverage >= 7.3.2",


### PR DESCRIPTION
Currently based off #24
I figure all dependencies currently under `[optional-dependencies]` are not meant to be user facing.